### PR TITLE
coregrind/m_debuglog.c: Fix debug logging on FreeBSD

### DIFF
--- a/coregrind/m_debuglog.c
+++ b/coregrind/m_debuglog.c
@@ -491,8 +491,8 @@ static UInt local_sys_write_stderr ( HChar* buf, Int n )
       "popq  %%r15\n"           /* restore r15 */
       "addq  $256, %%rsp\n"     /* restore stack ptr */
       : /*wr*/
-      : /*rd*/    "g" (block)
-      : /*trash*/ "rax", "rdi", "rsi", "rdx", "memory", "cc"
+      : /*rd*/    "r" (block)
+      : /*trash*/ "rax", "rdi", "rsi", "rdx", "memory", "cc", "rcx", "r11"
    );
    if (block[0] < 0) 
       block[0] = -1;


### PR DESCRIPTION
Fix incorrect assembly for amd64-freebsd. Based on similar fixes
for amd64-linux in commits f06f0f718 and 6b92194ac.